### PR TITLE
Add FullStory cloud mode destination trackEvent action

### DIFF
--- a/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
@@ -65,10 +65,8 @@ describe('FullStory', () => {
           event_name: eventName,
           event_data: properties,
           timestamp,
-          session: {
-            use_recent_session: properties.useRecentSession,
-            session_url: properties.sessionUrl
-          }
+          use_recent_session: properties.useRecentSession,
+          session_url: properties.sessionUrl
         }
       })
     })

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
@@ -48,6 +48,7 @@ describe('FullStory', () => {
       const [response] = await testDestination.testAction('trackEvent', {
         settings,
         event,
+        // Default mappings defined under fields in ../trackEvent/index.ts
         useDefaultMappings: true,
         mapping: {
           useRecentSession: {

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
@@ -14,14 +14,94 @@ const testDestination = createTestIntegration(Definition)
 
 describe('FullStory', () => {
   describe('testAuthentication', () => {
-    it(`makes expected request`, async () => {
+    it('makes expected request', async () => {
       nock(baseUrl).get('/operations/v1?limit=1').reply(200)
       await expect(testDestination.testAuthentication(settings)).resolves.not.toThrowError()
     })
   })
 
+  describe('trackEvent', () => {
+    it('makes expected request with default mappings', async () => {
+      nock(baseUrl).post(`/users/v1/individual/${userId}/customevent`).reply(200)
+      const eventName = 'test-event'
+
+      const properties = {
+        eventData: {
+          'first-property': 'first-value',
+          second_property: 'second_value',
+          thirdProperty: 'thirdValue'
+        },
+        useRecentSession: true,
+        sessionUrl: 'session-url'
+      }
+
+      const timestamp = new Date(Date.UTC(2022, 1, 2, 3, 4, 5)).toISOString()
+
+      const event = createTestEvent({
+        type: 'track',
+        userId,
+        event: eventName,
+        timestamp,
+        properties
+      })
+
+      const [response] = await testDestination.testAction('trackEvent', {
+        settings,
+        event,
+        useDefaultMappings: true,
+        mapping: {
+          useRecentSession: {
+            '@path': '$.properties.useRecentSession'
+          },
+          sessionUrl: {
+            '@path': '$.properties.sessionUrl'
+          }
+        }
+      })
+
+      expect(response.status).toBe(200)
+      expect(JSON.parse(response.options.body as string)).toEqual({
+        event: {
+          event_name: eventName,
+          event_data: properties,
+          timestamp,
+          session: {
+            use_recent_session: properties.useRecentSession,
+            session_url: properties.sessionUrl
+          }
+        }
+      })
+    })
+
+    it('handles undefined event values', async () => {
+      nock(baseUrl).post(`/users/v1/individual/${userId}/customevent`).reply(200)
+      const eventName = 'test-event'
+
+      const event = createTestEvent({
+        type: 'track',
+        userId,
+        event: eventName,
+        timestamp: undefined
+      })
+
+      const [response] = await testDestination.testAction('trackEvent', {
+        settings,
+        event,
+        useDefaultMappings: true
+      })
+
+      expect(response.status).toBe(200)
+      expect(JSON.parse(response.options.body as string)).toEqual({
+        event: {
+          event_name: eventName,
+          event_data: {}
+        }
+      })
+    })
+  })
+
   describe('identifyUser', () => {
-    it(`makes expected request with default mappings`, async () => {
+    it('makes expected request with default mappings', async () => {
       nock(baseUrl).post(`/users/v1/individual/${userId}/customvars`).reply(200)
       const event = createTestEvent({
         type: 'identify',
@@ -43,6 +123,7 @@ describe('FullStory', () => {
       })
 
       expect(response.status).toBe(200)
+      // TODO(nate): Consider using .toEqual for full deep equality verification
       expect(JSON.parse(response.options.body as string)).toMatchObject({
         segmentAnonymousId_str: anonymousId,
         email,
@@ -55,7 +136,7 @@ describe('FullStory', () => {
   })
 
   describe('onDelete', () => {
-    it(`makes expected request`, async () => {
+    it('makes expected request', async () => {
       nock(baseUrl).delete(`/users/v1/individual/${userId}`).reply(200)
       const jsonSettings = {
         apiKey: settings.apiKey

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
@@ -41,10 +41,8 @@ describe('requestParams', () => {
           event_name: requestValues.eventName,
           event_data: requestValues.eventData,
           timestamp: requestValues.timestamp,
-          session: {
-            use_recent_session: requestValues.useRecentSession,
-            session_url: requestValues.sessionUrl
-          }
+          use_recent_session: requestValues.useRecentSession,
+          session_url: requestValues.sessionUrl
         }
       })
     })

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
@@ -1,4 +1,9 @@
-import { listOperationsRequestParams, setUserPropertiesRequestParams, deleteUserRequestParams } from '../request-params'
+import {
+  listOperationsRequestParams,
+  customEventRequestParams,
+  setUserPropertiesRequestParams,
+  deleteUserRequestParams
+} from '../request-params'
 import { anonymousId, displayName, email, userId, baseUrl, settings } from './fullstory.test'
 
 describe('requestParams', () => {
@@ -12,8 +17,60 @@ describe('requestParams', () => {
     })
   })
 
+  describe('customEventRequestParams', () => {
+    it('returns expected request params', () => {
+      const requestValues = {
+        userId,
+        eventName: 'test-event',
+        eventData: {
+          'first-property': 'first-value',
+          second_property: 'second_value',
+          thirdProperty: 'thirdValue'
+        },
+        timestamp: new Date(Date.UTC(2022, 1, 2, 3, 4, 5)).toISOString(),
+        useRecentSession: true,
+        sessionUrl: 'session-url'
+      }
+      const { url, options } = customEventRequestParams(settings, requestValues)
+      expect(options.method).toBe('post')
+      expect(options.headers!['Content-Type']).toBe('application/json')
+      expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
+      expect(url).toBe(`${baseUrl}/users/v1/individual/${userId}/customevent`)
+      expect(options.json).toEqual({
+        event: {
+          event_name: requestValues.eventName,
+          event_data: requestValues.eventData,
+          timestamp: requestValues.timestamp,
+          session: {
+            use_recent_session: requestValues.useRecentSession,
+            session_url: requestValues.sessionUrl
+          }
+        }
+      })
+    })
+
+    it('handles undefined request values', () => {
+      const requestValues = {
+        userId,
+        eventName: 'test-event',
+        eventData: {}
+      }
+      const { url, options } = customEventRequestParams(settings, requestValues)
+      expect(options.method).toBe('post')
+      expect(options.headers!['Content-Type']).toBe('application/json')
+      expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
+      expect(url).toBe(`${baseUrl}/users/v1/individual/${userId}/customevent`)
+      expect(options.json).toEqual({
+        event: {
+          event_name: requestValues.eventName,
+          event_data: requestValues.eventData
+        }
+      })
+    })
+  })
+
   describe('setUserProperties', () => {
-    it(`returns expected request params`, () => {
+    it('returns expected request params', () => {
       const requestBody = {
         anonymousId,
         traits: {
@@ -31,7 +88,7 @@ describe('requestParams', () => {
   })
 
   describe('deleteUser', () => {
-    it(`returns expected request params`, () => {
+    it('returns expected request params', () => {
       const { url, options } = deleteUserRequestParams(settings, userId)
       expect(options.method).toBe('delete')
       expect(options.headers!['Content-Type']).toBe('application/json')

--- a/packages/destination-actions/src/destinations/fullstory/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/index.ts
@@ -2,6 +2,7 @@ import type { DestinationDefinition } from '@segment/actions-core'
 import { defaultValues } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 import identifyUser from './identifyUser'
+import trackEvent from './trackEvent'
 import { listOperationsRequestParams, deleteUserRequestParams } from './request-params'
 
 const destination: DestinationDefinition<Settings> = {
@@ -9,6 +10,12 @@ const destination: DestinationDefinition<Settings> = {
   slug: 'actions-fullstory',
   mode: 'cloud',
   presets: [
+    {
+      name: 'Track Event',
+      subscribe: 'type = "track"',
+      partnerAction: 'trackEvent',
+      mapping: defaultValues(trackEvent.fields)
+    },
     {
       name: 'Identify User',
       subscribe: 'type = "identify"',
@@ -39,6 +46,7 @@ const destination: DestinationDefinition<Settings> = {
   },
 
   actions: {
+    trackEvent,
     identifyUser
   }
 }

--- a/packages/destination-actions/src/destinations/fullstory/request-params.ts
+++ b/packages/destination-actions/src/destinations/fullstory/request-params.ts
@@ -35,6 +35,8 @@ const defaultRequestParams = (settings: Settings, relativeUrl: string): RequestP
   }
 }
 
+// TODO(nate): Remove "region specific" comments
+
 /**
  * Returns the region specific {@link RequestParams} for the list operations HTTP API endpoint.
  *
@@ -42,6 +44,58 @@ const defaultRequestParams = (settings: Settings, relativeUrl: string): RequestP
  */
 export const listOperationsRequestParams = (settings: Settings): RequestParams =>
   defaultRequestParams(settings, `operations/v1?limit=1`)
+
+/**
+ * Returns {@link RequestParams} for the custom events HTTP API endpoint.
+ *
+ * @param settings Settings configured for the cloud mode destination.
+ * @param requestValues Values to send with the request.
+ */
+export const customEventRequestParams = (
+  settings: Settings,
+  requestValues: {
+    userId: string
+    eventName: string
+    eventData: {}
+    timestamp?: string
+    useRecentSession?: boolean
+    sessionUrl?: string
+  }
+): RequestParams => {
+  const { userId, eventName, eventData, timestamp, useRecentSession, sessionUrl } = requestValues
+  const defaultParams = defaultRequestParams(settings, `users/v1/individual/${userId}/customevent`)
+
+  const requestBody: Record<string, any> = {
+    event: {
+      event_name: eventName,
+      event_data: eventData
+    }
+  }
+
+  if (timestamp) {
+    requestBody.event.timestamp = timestamp
+  }
+
+  if (useRecentSession !== undefined) {
+    requestBody.event.session = {
+      use_recent_session: useRecentSession
+    }
+  }
+
+  if (sessionUrl) {
+    requestBody.event.session = requestBody.event.session || {}
+    requestBody.event.session.session_url = sessionUrl
+  }
+
+  return {
+    ...defaultParams,
+    options: {
+      ...defaultParams.options,
+      method: 'post',
+      json: requestBody
+    }
+  }
+}
 
 /**
  * Returns the region specific {@link RequestParams} for the set user properties HTTP API endpoint.
@@ -58,6 +112,7 @@ export const setUserPropertiesRequestParams = (settings: Settings, userId: ID, r
     options: {
       ...defaultParams.options,
       method: 'post',
+      // TODO(nate): Specify json instead of body which will JSON.stringify for us and set the correct content-type header
       body: JSON.stringify(requestBody)
     }
   }

--- a/packages/destination-actions/src/destinations/fullstory/request-params.ts
+++ b/packages/destination-actions/src/destinations/fullstory/request-params.ts
@@ -77,14 +77,11 @@ export const customEventRequestParams = (
   }
 
   if (useRecentSession !== undefined) {
-    requestBody.event.session = {
-      use_recent_session: useRecentSession
-    }
+    requestBody.event.use_recent_session = useRecentSession
   }
 
   if (sessionUrl) {
-    requestBody.event.session = requestBody.event.session || {}
-    requestBody.event.session.session_url = sessionUrl
+    requestBody.event.session_url = sessionUrl
   }
 
   return {

--- a/packages/destination-actions/src/destinations/fullstory/trackEvent/generated-types.ts
+++ b/packages/destination-actions/src/destinations/fullstory/trackEvent/generated-types.ts
@@ -1,0 +1,30 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The user's id
+   */
+  userId: string
+  /**
+   * The name of the event.
+   */
+  name: string
+  /**
+   * A JSON object containing additional information about the event that will be indexed by FullStory.
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+  /**
+   * The date and time when the event occurred. If not provided, the current FullStory server time will be used.
+   */
+  timestamp?: string | number
+  /**
+   * Set to true if the custom event should be attached to the user's most recent session. The most recent session must have had activity within the past 30 minutes.
+   */
+  useRecentSession?: boolean
+  /**
+   * If known, the FullStory session playback URL to which the event should be attached, as returned by the FS.getCurrentSessionURL() client API.
+   */
+  sessionUrl?: string
+}

--- a/packages/destination-actions/src/destinations/fullstory/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/trackEvent/index.ts
@@ -1,0 +1,82 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import dayjs from '../../../lib/dayjs'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { customEventRequestParams } from '../request-params'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Track Event',
+  description: 'Track events',
+  platform: 'cloud',
+  defaultSubscription: 'type = "track"',
+  fields: {
+    userId: {
+      type: 'string',
+      required: true,
+      description: "The user's id",
+      label: 'User ID',
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    name: {
+      description: 'The name of the event.',
+      label: 'Name',
+      required: true,
+      type: 'string',
+      default: {
+        '@path': '$.event'
+      }
+    },
+    properties: {
+      description: 'A JSON object containing additional information about the event that will be indexed by FullStory.',
+      label: 'Properties',
+      required: false,
+      type: 'object',
+      default: {
+        '@path': '$.properties'
+      }
+    },
+    timestamp: {
+      description:
+        'The date and time when the event occurred. If not provided, the current FullStory server time will be used.',
+      label: 'Timestamp',
+      required: false,
+      type: 'datetime',
+      default: {
+        '@path': '$.timestamp'
+      }
+    },
+    useRecentSession: {
+      description:
+        "Set to true if the custom event should be attached to the user's most recent session. The most recent session must have had activity within the past 30 minutes.",
+      label: 'Use Recent Session',
+      required: false,
+      type: 'boolean'
+    },
+    sessionUrl: {
+      description:
+        'If known, the FullStory session playback URL to which the event should be attached, as returned by the FS.getCurrentSessionURL() client API.',
+      label: 'Session URL',
+      required: false,
+      type: 'string'
+    }
+  },
+  perform: (request, { payload, settings }) => {
+    const { userId, name, properties, timestamp, useRecentSession, sessionUrl } = payload
+    const utcTimestamp = timestamp ? dayjs.utc(timestamp) : undefined
+
+    // TODO(nate): Include a source value once the HTTP API is updated to support it
+    const { url, options } = customEventRequestParams(settings, {
+      userId,
+      eventName: name,
+      eventData: properties || {},
+      timestamp: utcTimestamp && utcTimestamp.isValid() ? utcTimestamp.toISOString() : undefined,
+      useRecentSession,
+      sessionUrl
+    })
+    return request(url, options)
+  }
+}
+
+export default action


### PR DESCRIPTION
Adds a `trackEvent` action to the FullStory cloud mode destination.

Note: This PR is set to merge into an aggregate branch for implementing the FullStory cloud mode destination which is our target for Segment to review.

## Testing

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
