### PR TITLE
URL encode userId in FullStory API URLs

### DIFF
--- a/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
@@ -3,7 +3,8 @@ import { createTestEvent, createTestIntegration } from '@segment/actions-core'
 import Definition from '../index'
 
 export const apiKey = 'fake-api-key'
-export const userId = 'fake-user-id'
+export const userId = 'fake/user/id'
+export const urlEncodedUserId = encodeURIComponent(userId)
 export const anonymousId = 'fake-anonymous-id'
 export const email = 'fake+email@example.com'
 export const displayName = 'fake-display-name'
@@ -22,7 +23,7 @@ describe('FullStory', () => {
 
   describe('trackEvent', () => {
     it('makes expected request with default mappings', async () => {
-      nock(baseUrl).post(`/users/v1/individual/${userId}/customevent`).reply(200)
+      nock(baseUrl).post(`/users/v1/individual/${urlEncodedUserId}/customevent`).reply(200)
       const eventName = 'test-event'
 
       const properties = {
@@ -73,7 +74,7 @@ describe('FullStory', () => {
     })
 
     it('handles undefined event values', async () => {
-      nock(baseUrl).post(`/users/v1/individual/${userId}/customevent`).reply(200)
+      nock(baseUrl).post(`/users/v1/individual/${urlEncodedUserId}/customevent`).reply(200)
       const eventName = 'test-event'
 
       const event = createTestEvent({
@@ -101,7 +102,7 @@ describe('FullStory', () => {
 
   describe('identifyUser', () => {
     it('makes expected request with default mappings', async () => {
-      nock(baseUrl).post(`/users/v1/individual/${userId}/customvars`).reply(200)
+      nock(baseUrl).post(`/users/v1/individual/${urlEncodedUserId}/customvars`).reply(200)
       const event = createTestEvent({
         type: 'identify',
         userId,
@@ -135,7 +136,7 @@ describe('FullStory', () => {
 
   describe('onDelete', () => {
     it('makes expected request', async () => {
-      nock(baseUrl).delete(`/users/v1/individual/${userId}`).reply(200)
+      nock(baseUrl).delete(`/users/v1/individual/${urlEncodedUserId}`).reply(200)
       await expect(testDestination.onDelete!({ type: 'delete', userId }, settings)).resolves.not.toThrowError()
     })
   })

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
@@ -4,7 +4,7 @@ import {
   setUserPropertiesRequestParams,
   deleteUserRequestParams
 } from '../request-params'
-import { anonymousId, displayName, email, userId, baseUrl, settings } from './fullstory.test'
+import { anonymousId, displayName, email, userId, urlEncodedUserId, baseUrl, settings } from './fullstory.test'
 
 describe('requestParams', () => {
   describe('listOperations', () => {
@@ -35,7 +35,7 @@ describe('requestParams', () => {
       expect(options.method).toBe('post')
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
-      expect(url).toBe(`${baseUrl}/users/v1/individual/${userId}/customevent`)
+      expect(url).toBe(`${baseUrl}/users/v1/individual/${urlEncodedUserId}/customevent`)
       expect(options.json).toEqual({
         event: {
           event_name: requestValues.eventName,
@@ -57,7 +57,7 @@ describe('requestParams', () => {
       expect(options.method).toBe('post')
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
-      expect(url).toBe(`${baseUrl}/users/v1/individual/${userId}/customevent`)
+      expect(url).toBe(`${baseUrl}/users/v1/individual/${urlEncodedUserId}/customevent`)
       expect(options.json).toEqual({
         event: {
           event_name: requestValues.eventName,
@@ -80,7 +80,7 @@ describe('requestParams', () => {
       expect(options.method).toBe('post')
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
-      expect(url).toBe(`${baseUrl}/users/v1/individual/${userId}/customvars`)
+      expect(url).toBe(`${baseUrl}/users/v1/individual/${urlEncodedUserId}/customvars`)
       expect(options.json).toEqual(requestBody)
     })
   })
@@ -91,7 +91,7 @@ describe('requestParams', () => {
       expect(options.method).toBe('delete')
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
-      expect(url).toBe(`${baseUrl}/users/v1/individual/${userId}`)
+      expect(url).toBe(`${baseUrl}/users/v1/individual/${urlEncodedUserId}`)
     })
   })
 })

--- a/packages/destination-actions/src/destinations/fullstory/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/index.ts
@@ -41,6 +41,9 @@ const destination: DestinationDefinition<Settings> = {
   },
 
   onDelete: async (request, { settings, payload }) => {
+    if (payload.userId === null || payload.userId === undefined) {
+      return
+    }
     const { url, options } = deleteUserRequestParams(settings, payload.userId)
     return request(url, options)
   },

--- a/packages/destination-actions/src/destinations/fullstory/request-params.ts
+++ b/packages/destination-actions/src/destinations/fullstory/request-params.ts
@@ -2,11 +2,6 @@ import type { RequestOptions } from '@segment/actions-core'
 import type { Settings } from './generated-types'
 
 /**
- * Mirrors the ID type which isn't exported from the @segment/actions-core package root.
- */
-type ID = string | null | undefined
-
-/**
  * Parameters intended to be passed into a RequestClient.
  */
 interface RequestParams {
@@ -61,7 +56,7 @@ export const customEventRequestParams = (
   }
 ): RequestParams => {
   const { userId, eventName, eventData, timestamp, useRecentSession, sessionUrl } = requestValues
-  const defaultParams = defaultRequestParams(settings, `users/v1/individual/${userId}/customevent`)
+  const defaultParams = defaultRequestParams(settings, `users/v1/individual/${encodeURIComponent(userId)}/customevent`)
 
   const requestBody: Record<string, any> = {
     event: {
@@ -99,8 +94,12 @@ export const customEventRequestParams = (
  * @param userId The id of the user to update.
  * @param requestBody The request body containing user properties to set.
  */
-export const setUserPropertiesRequestParams = (settings: Settings, userId: ID, requestBody: Object): RequestParams => {
-  const defaultParams = defaultRequestParams(settings, `users/v1/individual/${userId}/customvars`)
+export const setUserPropertiesRequestParams = (
+  settings: Settings,
+  userId: string,
+  requestBody: Object
+): RequestParams => {
+  const defaultParams = defaultRequestParams(settings, `users/v1/individual/${encodeURIComponent(userId)}/customvars`)
 
   return {
     ...defaultParams,
@@ -118,8 +117,8 @@ export const setUserPropertiesRequestParams = (settings: Settings, userId: ID, r
  * @param settings Settings configured for the cloud mode destination.
  * @param userId The id of the user to delete.
  */
-export const deleteUserRequestParams = (settings: Settings, userId: ID): RequestParams => {
-  const defaultParams = defaultRequestParams(settings, `users/v1/individual/${userId}`)
+export const deleteUserRequestParams = (settings: Settings, userId: string): RequestParams => {
+  const defaultParams = defaultRequestParams(settings, `users/v1/individual/${encodeURIComponent(userId)}`)
 
   return {
     ...defaultParams,


### PR DESCRIPTION
Encodes `userId` values in FullStory API URLs.

## Testing

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
