### PR TITLE
Omit use_recent_session request param if value is false

### DIFF
--- a/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
@@ -65,6 +65,26 @@ describe('requestParams', () => {
         }
       })
     })
+
+    it('omits use_recent_session request param if false', () => {
+      const requestValues = {
+        userId,
+        eventName: 'test-event',
+        eventData: {},
+        useRecentSession: false
+      }
+      const { url, options } = customEventRequestParams(settings, requestValues)
+      expect(options.method).toBe('post')
+      expect(options.headers!['Content-Type']).toBe('application/json')
+      expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
+      expect(url).toBe(`${baseUrl}/users/v1/individual/${urlEncodedUserId}/customevent`)
+      expect(options.json).toEqual({
+        event: {
+          event_name: requestValues.eventName,
+          event_data: requestValues.eventData
+        }
+      })
+    })
   })
 
   describe('setUserProperties', () => {

--- a/packages/destination-actions/src/destinations/fullstory/request-params.ts
+++ b/packages/destination-actions/src/destinations/fullstory/request-params.ts
@@ -69,7 +69,10 @@ export const customEventRequestParams = (
     requestBody.event.timestamp = timestamp
   }
 
-  if (useRecentSession !== undefined) {
+  // TODO(nate): We're intentionally omitting the use_recent_session request param when the given value is false. At
+  // time of writing, the API will treat use_recent_session=false as use_recent_session=true. This can be removed in
+  // the future when this bug is fixed in the API.
+  if (useRecentSession) {
     requestBody.event.use_recent_session = useRecentSession
   }
 


### PR DESCRIPTION
Work around a bug in the custom event API which treats `use_recent_session=false` as `use_recent_session=true`.

Note: This is merging into an aggregate branch intended to be reviewed by Segment to create the FullStory cloud mode destination.

## Testing

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
