### PR TITLE
Type suffix FullStory cloud mode destination custom vars

### DIFF
--- a/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
@@ -114,9 +114,10 @@ describe('FullStory', () => {
         traits: {
           email,
           name: displayName,
-          'originally-hyphenated': true,
+          'originally-hyphenated': 'some string',
           'originally spaced': true,
-          typeSuffixed_str: true
+          typeSuffixed_bool: true,
+          'originally.dotted': 1.23
         }
       })
 
@@ -134,9 +135,10 @@ describe('FullStory', () => {
         email_str: email,
         displayName,
         name_str: displayName,
-        originallyHyphenated_bool: true,
+        originallyHyphenated_str: 'some string',
         originallySpaced_bool: true,
-        typeSuffixed_str: true
+        typeSuffixed_bool: true,
+        originallyDotted_real: 1.23
       })
     })
   })

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
@@ -27,11 +27,9 @@ describe('FullStory', () => {
       const eventName = 'test-event'
 
       const properties = {
-        eventData: {
-          'first-property': 'first-value',
-          second_property: 'second_value',
-          thirdProperty: 'thirdValue'
-        },
+        'first-property': 'first-value',
+        second_property: 'second_value',
+        thirdProperty: 'thirdValue',
         useRecentSession: true,
         sessionUrl: 'session-url'
       }
@@ -65,7 +63,13 @@ describe('FullStory', () => {
       expect(JSON.parse(response.options.body as string)).toEqual({
         event: {
           event_name: eventName,
-          event_data: properties,
+          event_data: {
+            'first-property_str': properties['first-property'],
+            second_property_str: properties.second_property,
+            thirdProperty_str: properties.thirdProperty,
+            useRecentSession_bool: properties.useRecentSession,
+            sessionUrl_str: properties.sessionUrl
+          },
           timestamp,
           use_recent_session: properties.useRecentSession,
           session_url: properties.sessionUrl
@@ -109,7 +113,7 @@ describe('FullStory', () => {
         anonymousId,
         traits: {
           email,
-          displayName,
+          name: displayName,
           'originally-hyphenated': true,
           'originally spaced': true,
           typeSuffixed_str: true
@@ -126,9 +130,12 @@ describe('FullStory', () => {
       expect(JSON.parse(response.options.body as string)).toEqual({
         segmentAnonymousId_str: anonymousId,
         email,
+        // TODO(nate): See if we can eliminate duplicate email_str and name_str data based on mapping config.
+        email_str: email,
         displayName,
-        originallyHyphenated: true,
-        originallySpaced: true,
+        name_str: displayName,
+        originallyHyphenated_bool: true,
+        originallySpaced_bool: true,
         typeSuffixed_str: true
       })
     })

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
@@ -3,10 +3,10 @@ import { normalizePropertyNames } from '../vars'
 const suffixToExampleValuesMap: Record<string, any[]> = {
   str: ['some string'],
   bool: [true, false],
-  real: [1.23],
+  real: [1, 1.23],
   int: [1],
   date: [new Date()],
-  obj: [{}]
+  obj: [{}, { secondLevelProp: 'some value' }]
 }
 
 suffixToExampleValuesMap.strs = [suffixToExampleValuesMap.str]
@@ -45,10 +45,12 @@ describe('normalizePropertyNames', () => {
       string_prop: suffixToExampleValuesMap.str[0],
       bool_prop1: suffixToExampleValuesMap.bool[0],
       bool_prop2: suffixToExampleValuesMap.bool[1],
-      real_prop: suffixToExampleValuesMap.real[0],
+      real_prop1: suffixToExampleValuesMap.real[0],
+      real_prop2: suffixToExampleValuesMap.real[1],
       int_prop: suffixToExampleValuesMap.int[0],
       date_prop: suffixToExampleValuesMap.date[0],
-      obj_prop: suffixToExampleValuesMap.obj[0],
+      obj_prop1: suffixToExampleValuesMap.obj[0],
+      obj_prop2: suffixToExampleValuesMap.obj[1],
       strs_prop: suffixToExampleValuesMap.strs[0],
       bools_prop: suffixToExampleValuesMap.bools[0],
       reals_prop: suffixToExampleValuesMap.reals[0],
@@ -60,12 +62,14 @@ describe('normalizePropertyNames', () => {
       string_prop_str: obj.string_prop,
       bool_prop1_bool: obj.bool_prop1,
       bool_prop2_bool: obj.bool_prop2,
-      real_prop_real: obj.real_prop,
-      // This seems counter-intuitive, but this matches the FullStory client API behavior which prefers reals
-      // over ints to avoid inconsistent type inference.
+      real_prop1_real: obj.real_prop1,
+      real_prop2_real: obj.real_prop2,
+      // This may seem counter-intuitive, but this matches the FullStory client API behavior which prefers
+      // reals over ints to avoid inconsistent type inference.
       int_prop_real: obj.int_prop,
       date_prop_date: obj.date_prop,
-      obj_prop_obj: obj.obj_prop,
+      obj_prop1_obj: obj.obj_prop1,
+      obj_prop2_obj: obj.obj_prop2,
       strs_prop_strs: obj.strs_prop,
       bools_prop_bools: obj.bools_prop,
       reals_prop_reals: obj.reals_prop,

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
@@ -1,0 +1,100 @@
+import { normalizeVarNames } from '../vars'
+
+const suffixToExampleValuesMap: Record<string, any[]> = {
+  str: ['some string'],
+  bool: [true, false],
+  real: [1.23],
+  int: [1],
+  date: [new Date()],
+  obj: [{}]
+}
+
+suffixToExampleValuesMap.strs = [suffixToExampleValuesMap.str]
+suffixToExampleValuesMap.bools = [suffixToExampleValuesMap.bool]
+suffixToExampleValuesMap.reals = [suffixToExampleValuesMap.real]
+suffixToExampleValuesMap.ints = [suffixToExampleValuesMap.int]
+suffixToExampleValuesMap.dates = [suffixToExampleValuesMap.date]
+suffixToExampleValuesMap.objs = [suffixToExampleValuesMap.obj]
+
+describe('normalizeVarNames', () => {
+  it('does not add type suffix for undefined values', () => {
+    const obj = {
+      someProp: undefined
+    }
+    const normalizedObj = normalizeVarNames(obj)
+    expect(normalizedObj).toEqual(obj)
+  })
+
+  it('returns empty object given undefined object', () => {
+    expect(normalizeVarNames(undefined)).toEqual({})
+  })
+
+  it('does not add type suffix if known type suffix is present', () => {
+    const obj: Record<string, unknown> = {}
+    Object.entries(suffixToExampleValuesMap).forEach(([suffix, values]) => {
+      values.forEach((value, index) => {
+        obj[`prop${index}_${suffix}`] = value
+      })
+    })
+    const normalizedObj = normalizeVarNames(obj)
+    expect(normalizedObj).toEqual(obj)
+  })
+
+  it('adds type suffixes when type can be inferred and known type suffix is absent', () => {
+    const obj = {
+      string_prop: suffixToExampleValuesMap.str[0],
+      bool_prop1: suffixToExampleValuesMap.bool[0],
+      bool_prop2: suffixToExampleValuesMap.bool[1],
+      real_prop: suffixToExampleValuesMap.real[0],
+      int_prop: suffixToExampleValuesMap.int[0],
+      date_prop: suffixToExampleValuesMap.date[0],
+      obj_prop: suffixToExampleValuesMap.obj[0],
+      strs_prop: suffixToExampleValuesMap.strs[0],
+      bools_prop: suffixToExampleValuesMap.bools[0],
+      reals_prop: suffixToExampleValuesMap.reals[0],
+      ints_prop: suffixToExampleValuesMap.ints[0],
+      dates_prop: suffixToExampleValuesMap.dates[0],
+      objs_prop: suffixToExampleValuesMap.objs[0]
+    }
+    const expected = {
+      string_prop_str: obj.string_prop,
+      bool_prop1_bool: obj.bool_prop1,
+      bool_prop2_bool: obj.bool_prop2,
+      real_prop_real: obj.real_prop,
+      // This seems counter-intuitive, but this matches the FullStory client API behavior which prefers reals
+      // over ints to avoid inconsistent type inference.
+      int_prop_real: obj.int_prop,
+      date_prop_date: obj.date_prop,
+      obj_prop_obj: obj.obj_prop,
+      strs_prop_strs: obj.strs_prop,
+      bools_prop_bools: obj.bools_prop,
+      reals_prop_reals: obj.reals_prop,
+      ints_prop_reals: obj.ints_prop,
+      dates_prop_dates: obj.dates_prop,
+      objs_prop_objs: obj.objs_prop
+    }
+    const actual = normalizeVarNames(obj)
+    expect(actual).toEqual(expected)
+  })
+
+  it('camel cases when specified', () => {
+    const obj = {
+      string_str: 'some string',
+      moreStrings: ['more', 'strings'],
+      last_string_str: 'last string',
+      ['hyphenated-bool']: true,
+      'dotted.date': new Date(),
+      'spaced real': 1.23
+    }
+    const expected = {
+      string_str: obj.string_str,
+      moreStrings_strs: obj.moreStrings,
+      lastString_str: obj.last_string_str,
+      hyphenatedBool_bool: obj['hyphenated-bool'],
+      dottedDate_date: obj['dotted.date'],
+      spacedReal_real: obj['spaced real']
+    }
+    const actual = normalizeVarNames(obj, { camelCase: true })
+    expect(actual).toEqual(expected)
+  })
+})

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
@@ -3,6 +3,8 @@ import { normalizePropertyNames } from '../vars'
 const suffixToExampleValuesMap: Record<string, any[]> = {
   str: ['some string'],
   bool: [true, false],
+  // We include an int value with real example values since real will always be preferred when inferring
+  // custom var types from values.
   real: [1, 1.23],
   int: [1],
   date: [new Date()],

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
@@ -1,4 +1,4 @@
-import { normalizeVarNames } from '../vars'
+import { normalizePropertyNames } from '../vars'
 
 const suffixToExampleValuesMap: Record<string, any[]> = {
   str: ['some string'],
@@ -16,17 +16,17 @@ suffixToExampleValuesMap.ints = [suffixToExampleValuesMap.int]
 suffixToExampleValuesMap.dates = [suffixToExampleValuesMap.date]
 suffixToExampleValuesMap.objs = [suffixToExampleValuesMap.obj]
 
-describe('normalizeVarNames', () => {
+describe('normalizePropertyNames', () => {
   it('does not add type suffix for undefined values', () => {
     const obj = {
       someProp: undefined
     }
-    const normalizedObj = normalizeVarNames(obj)
+    const normalizedObj = normalizePropertyNames(obj)
     expect(normalizedObj).toEqual(obj)
   })
 
   it('returns empty object given undefined object', () => {
-    expect(normalizeVarNames(undefined)).toEqual({})
+    expect(normalizePropertyNames(undefined)).toEqual({})
   })
 
   it('does not add type suffix if known type suffix is present', () => {
@@ -36,7 +36,7 @@ describe('normalizeVarNames', () => {
         obj[`prop${index}_${suffix}`] = value
       })
     })
-    const normalizedObj = normalizeVarNames(obj)
+    const normalizedObj = normalizePropertyNames(obj)
     expect(normalizedObj).toEqual(obj)
   })
 
@@ -73,7 +73,7 @@ describe('normalizeVarNames', () => {
       dates_prop_dates: obj.dates_prop,
       objs_prop_objs: obj.objs_prop
     }
-    const actual = normalizeVarNames(obj)
+    const actual = normalizePropertyNames(obj)
     expect(actual).toEqual(expected)
   })
 
@@ -94,7 +94,7 @@ describe('normalizeVarNames', () => {
       dottedDate_date: obj['dotted.date'],
       spacedReal_real: obj['spaced real']
     }
-    const actual = normalizeVarNames(obj, { camelCase: true })
+    const actual = normalizePropertyNames(obj, { camelCase: true })
     expect(actual).toEqual(expected)
   })
 })

--- a/packages/destination-actions/src/destinations/fullstory/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/identifyUser/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
 import type { Settings } from '../generated-types'
 import { setUserPropertiesRequestParams } from '../request-params'
-import { normalizeVarNames } from '../vars'
+import { normalizePropertyNames } from '../vars'
 
 const action: ActionDefinition<Settings> = {
   title: 'Identify User',
@@ -58,7 +58,7 @@ const action: ActionDefinition<Settings> = {
   perform: (request, { payload, settings }) => {
     const { traits, anonymousId, userId, email, displayName } = payload
 
-    const normalizedTraits = normalizeVarNames(traits, { camelCase: true })
+    const normalizedTraits = normalizePropertyNames(traits, { camelCase: true })
 
     if (anonymousId) {
       normalizedTraits.segmentAnonymousId_str = anonymousId

--- a/packages/destination-actions/src/destinations/fullstory/identifyUser/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/identifyUser/index.ts
@@ -1,7 +1,7 @@
 import type { ActionDefinition } from '@segment/actions-core'
-import camelCase from 'lodash/camelCase'
 import type { Settings } from '../generated-types'
 import { setUserPropertiesRequestParams } from '../request-params'
+import { normalizeVarNames } from '../vars'
 
 const action: ActionDefinition<Settings> = {
   title: 'Identify User',
@@ -57,25 +57,16 @@ const action: ActionDefinition<Settings> = {
   },
   perform: (request, { payload, settings }) => {
     const { traits, anonymousId, userId, email, displayName } = payload
-    let newTraits: Record<string, unknown> = {}
 
-    if (traits) {
-      newTraits = Object.entries(traits).reduce(
-        (acc, [key, value]) => ({
-          ...acc,
-          [camelCaseField(key)]: value
-        }),
-        {}
-      )
-    }
+    const normalizedTraits = normalizeVarNames(traits, { camelCase: true })
 
     if (anonymousId) {
-      newTraits.segmentAnonymousId_str = anonymousId
+      normalizedTraits.segmentAnonymousId_str = anonymousId
     }
 
     // TODO(nate): Include a source value once the HTTP API is updated to support it
     const requestBody = {
-      ...newTraits,
+      ...normalizedTraits,
       ...(email !== undefined && { email }),
       ...(displayName !== undefined && { displayName })
     }
@@ -83,39 +74,6 @@ const action: ActionDefinition<Settings> = {
     const { url, options } = setUserPropertiesRequestParams(settings, userId, requestBody)
     return request(url, options)
   }
-}
-
-/**
- * Camel cases `.`, `-`, `_`, and white space within fieldNames. Leaves type suffix alone.
- *
- * NOTE: Does not fix otherwise malformed fieldNames.
- * FullStory will scrub characters from keys that do not conform to /^[a-zA-Z][a-zA-Z0-9_]*$/.
- *
- * @param {string} fieldName
- */
-function camelCaseField(fieldName: string) {
-  // Do not camel case across type suffixes.
-  const parts = fieldName.split('_')
-  if (parts.length > 1) {
-    const typeSuffix = parts.pop()
-    switch (typeSuffix) {
-      case 'str':
-      case 'int':
-      case 'date':
-      case 'real':
-      case 'bool':
-      case 'strs':
-      case 'ints':
-      case 'dates':
-      case 'reals':
-      case 'bools':
-        return camelCase(parts.join('_')) + '_' + typeSuffix
-      default: // passthrough
-    }
-  }
-
-  // No type suffix found. Camel case the whole field name.
-  return camelCase(fieldName)
 }
 
 export default action

--- a/packages/destination-actions/src/destinations/fullstory/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/trackEvent/index.ts
@@ -3,6 +3,7 @@ import dayjs from '../../../lib/dayjs'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { customEventRequestParams } from '../request-params'
+import { normalizeVarNames } from '../vars'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Track Event',
@@ -70,7 +71,7 @@ const action: ActionDefinition<Settings, Payload> = {
     const { url, options } = customEventRequestParams(settings, {
       userId,
       eventName: name,
-      eventData: properties || {},
+      eventData: normalizeVarNames(properties),
       timestamp: utcTimestamp && utcTimestamp.isValid() ? utcTimestamp.toISOString() : undefined,
       useRecentSession,
       sessionUrl

--- a/packages/destination-actions/src/destinations/fullstory/trackEvent/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/trackEvent/index.ts
@@ -3,7 +3,7 @@ import dayjs from '../../../lib/dayjs'
 import type { Settings } from '../generated-types'
 import type { Payload } from './generated-types'
 import { customEventRequestParams } from '../request-params'
-import { normalizeVarNames } from '../vars'
+import { normalizePropertyNames } from '../vars'
 
 const action: ActionDefinition<Settings, Payload> = {
   title: 'Track Event',
@@ -71,7 +71,7 @@ const action: ActionDefinition<Settings, Payload> = {
     const { url, options } = customEventRequestParams(settings, {
       userId,
       eventName: name,
-      eventData: normalizeVarNames(properties),
+      eventData: normalizePropertyNames(properties),
       timestamp: utcTimestamp && utcTimestamp.isValid() ? utcTimestamp.toISOString() : undefined,
       useRecentSession,
       sessionUrl

--- a/packages/destination-actions/src/destinations/fullstory/vars.ts
+++ b/packages/destination-actions/src/destinations/fullstory/vars.ts
@@ -14,8 +14,6 @@ const isDate = (x: any) => {
   }
   if (x.constructor === Date) {
     return !isNaN(x as any)
-  } else if (typeof x === 'number' || typeof x === 'string') {
-    return !isNaN(new Date(x) as any)
   }
   return false
 }
@@ -40,6 +38,8 @@ const typeValidators: Readonly<Record<string, (_: any) => boolean>> = {
   str: isString,
   bool: isBool,
   real: isReal,
+  // Even though we won't infer an int type suffix since real will be preferred, we maintain int and
+  // ints in this map since keys are also used to check for known type suffixes which we preserve.
   int: isInt,
   date: isDate,
   strs: isArrayOf(isString),

--- a/packages/destination-actions/src/destinations/fullstory/vars.ts
+++ b/packages/destination-actions/src/destinations/fullstory/vars.ts
@@ -1,0 +1,52 @@
+import camelCase from 'lodash/camelCase'
+
+/**
+ * Camel cases `.`, `-`, `_`, and white space within var names. Preserves type suffix casing.
+ *
+ * NOTE: Does not fix otherwise malformed fieldNames.
+ * FullStory will scrub characters from keys that do not conform to /^[a-zA-Z][a-zA-Z0-9_]*$/.
+ *
+ * @param {string} varName
+ */
+function camelCaseVarName(varName: string) {
+  // Do not camel case known type suffixes.
+  const parts = varName.split('_')
+  if (parts.length > 1) {
+    const typeSuffix = parts.pop()
+    switch (typeSuffix) {
+      case 'str':
+      case 'int':
+      case 'date':
+      case 'real':
+      case 'bool':
+      case 'strs':
+      case 'ints':
+      case 'dates':
+      case 'reals':
+      case 'bools':
+        return camelCase(parts.join('_')) + '_' + typeSuffix
+      default: // passthrough
+    }
+  }
+
+  // No type suffix found. Camel case the whole field name.
+  return camelCase(varName)
+}
+
+export const normalizeVarNames = (obj?: {}, options?: { camelCase?: boolean }): Record<string, unknown> => {
+  if (!options?.camelCase) {
+    return obj || {}
+  }
+
+  if (!obj) {
+    return {}
+  }
+
+  return Object.entries(obj).reduce(
+    (acc, [key, value]) => ({
+      ...acc,
+      [camelCaseVarName(key)]: value
+    }),
+    {}
+  )
+}

--- a/packages/destination-actions/src/destinations/fullstory/vars.ts
+++ b/packages/destination-actions/src/destinations/fullstory/vars.ts
@@ -1,51 +1,137 @@
 import camelCase from 'lodash/camelCase'
 
+const isString = (x: any) => typeof x === 'string'
+
+const isBool = (x: any) => typeof x === 'boolean'
+
+const isReal = (x: any) => typeof x === 'number'
+
+const isInt = (x: any) => typeof x === 'number' && x - Math.floor(x) === 0
+
+const isDate = (x: any) => {
+  if (!x) {
+    return false
+  }
+  if (x.constructor === Date) {
+    return !isNaN(x as any)
+  } else if (typeof x === 'number' || typeof x === 'string') {
+    return !isNaN(new Date(x) as any)
+  }
+  return false
+}
+
+const isArrayOf = (f: (val: any) => boolean) => {
+  return function (x: any): boolean {
+    if (!(x instanceof Array)) {
+      return false
+    }
+    for (let i = 0; i < x.length; i++) {
+      if (!f(x[i])) {
+        return false
+      }
+    }
+    return true
+  }
+}
+
+const isObject = (x: any) => {
+  if (!x) {
+    return false
+  }
+  return typeof x === 'object'
+}
+
+const varTypeValidators: Readonly<Record<string, (_: any) => boolean>> = {
+  str: isString,
+  bool: isBool,
+  real: isReal,
+  int: isInt,
+  date: isDate,
+  strs: isArrayOf(isString),
+  bools: isArrayOf(isBool),
+  reals: isArrayOf(isReal),
+  ints: isArrayOf(isInt),
+  dates: isArrayOf(isDate),
+  objs: isArrayOf(isObject),
+  obj: isObject
+}
+
+const inferType = (value: any) => {
+  for (const t in varTypeValidators) {
+    if (varTypeValidators[t](value)) {
+      return t
+    }
+  }
+  return null
+}
+
+const isKnownTypeSuffix = (suffix: string) => !!varTypeValidators[suffix]
+
 /**
  * Camel cases `.`, `-`, `_`, and white space within var names. Preserves type suffix casing.
  *
  * NOTE: Does not fix otherwise malformed fieldNames.
  * FullStory will scrub characters from keys that do not conform to /^[a-zA-Z][a-zA-Z0-9_]*$/.
  *
- * @param {string} varName
+ * @param {string} name
  */
-function camelCaseVarName(varName: string) {
+const camelCaseVarName = (name: string) => {
   // Do not camel case known type suffixes.
-  const parts = varName.split('_')
+  const parts = name.split('_')
   if (parts.length > 1) {
     const typeSuffix = parts.pop()
-    switch (typeSuffix) {
-      case 'str':
-      case 'int':
-      case 'date':
-      case 'real':
-      case 'bool':
-      case 'strs':
-      case 'ints':
-      case 'dates':
-      case 'reals':
-      case 'bools':
-        return camelCase(parts.join('_')) + '_' + typeSuffix
-      default: // passthrough
+    if (typeSuffix && varTypeValidators[typeSuffix]) {
+      return camelCase(parts.join('_')) + '_' + typeSuffix
     }
   }
 
   // No type suffix found. Camel case the whole field name.
-  return camelCase(varName)
+  return camelCase(name)
+}
+
+const typeSuffixVarName = (name: string, value: unknown) => {
+  const valueTypeName = typeof value
+
+  if (valueTypeName === 'undefined') {
+    // We can't infer the variable type for undefined values
+    return name
+  }
+
+  let lastUnderscore = name.lastIndexOf('_')
+
+  if (lastUnderscore === -1 || !isKnownTypeSuffix(name.substring(lastUnderscore + 1))) {
+    // Either no type suffix or the name contains an underscore with an unknown suffix.
+    const maybeType = inferType(value)
+    if (maybeType === null) {
+      // We can't infer the type. Don't change the var name.
+      return name
+    }
+
+    lastUnderscore = name.length
+    // TODO(nate): Consider further validation on name.
+    return `${name}_${maybeType}`
+  }
+
+  return name
 }
 
 export const normalizeVarNames = (obj?: {}, options?: { camelCase?: boolean }): Record<string, unknown> => {
-  if (!options?.camelCase) {
-    return obj || {}
-  }
-
   if (!obj) {
     return {}
+  }
+
+  const normalizeVarName = (name: string, value: unknown) => {
+    let transformedName = name
+    if (options?.camelCase) {
+      transformedName = camelCaseVarName(name)
+    }
+    return typeSuffixVarName(transformedName, value)
   }
 
   return Object.entries(obj).reduce(
     (acc, [key, value]) => ({
       ...acc,
-      [camelCaseVarName(key)]: value
+      [normalizeVarName(key, value)]: value
     }),
     {}
   )

--- a/packages/destination-actions/src/destinations/fullstory/vars.ts
+++ b/packages/destination-actions/src/destinations/fullstory/vars.ts
@@ -66,7 +66,6 @@ const isKnownTypeSuffix = (suffix: string) => !!typeValidators[suffix]
  * Camel cases `.`, `-`, `_`, and white space within property names. Preserves type suffix casing.
  *
  * NOTE: Does not fix otherwise malformed fieldNames.
- * FullStory will scrub characters from keys that do not conform to /^[a-zA-Z][a-zA-Z0-9_]*$/.
  *
  * @param {string} name
  */


### PR DESCRIPTION
Type suffixes custom vars in FullStory cloud mode destination `identifyUser` and `trackEvent` actions. This matches FullStory client API behavior and avoids requiring callers to type suffix property names in Segment events to avoid receiving status code 400 responses from FullStory API calls.

Note: This PR is targeted to merge into an aggregate branch creating the FullStory cloud mode destination. This branch is  intended to be reviewed by Segment.

## Testing

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
