### PR TITLE
Strip unsupported FullStory property name chars

### DIFF
--- a/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
@@ -67,7 +67,7 @@ describe('FullStory', () => {
         event: {
           event_name: eventName,
           event_data: {
-            'first-property_str': properties['first-property'],
+            firstproperty_str: properties['first-property'],
             second_property_str: properties.second_property,
             thirdProperty_str: properties.thirdProperty,
             useRecentSession_bool: properties.useRecentSession,

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
@@ -103,4 +103,45 @@ describe('normalizePropertyNames', () => {
     const actual = normalizePropertyNames(obj, { camelCase: true })
     expect(actual).toEqual(expected)
   })
+
+  const unsupportedPropertyNameChars = [' ', '.', '-', ':']
+
+  unsupportedPropertyNameChars.forEach((char) => {
+    it(`strips unsupported char '${char}' from property nama`, () => {
+      const originalNameIncludingTypeSuffix = `type${char}_suffixed${char}${char}_property_str`
+      const expectedNamePreservingTypeSuffix = 'type_suffixed_property_str'
+
+      const originalNameExcludingTypeSuffix = `type${char}${char}_without${char}_suffix`
+      const expectedNameAddingTypeSuffix = 'type_without_suffix_str'
+
+      const obj = {
+        [originalNameIncludingTypeSuffix]: 'some-string',
+        [originalNameExcludingTypeSuffix]: 'some-other-string'
+      }
+
+      const expected = {
+        [expectedNamePreservingTypeSuffix]: obj[originalNameIncludingTypeSuffix],
+        [expectedNameAddingTypeSuffix]: obj[originalNameExcludingTypeSuffix]
+      }
+
+      const actual = normalizePropertyNames(obj)
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  it('camel cases before stripping supported property name chars', () => {
+    const originalNameIncludingTypeSuffix = 'type.including camel-case:targets_str'
+    const expectedNamePreservingTypeSuffix = 'typeIncludingCamelCaseTargets_str'
+
+    const obj = {
+      [originalNameIncludingTypeSuffix]: 'some-string'
+    }
+
+    const expected = {
+      [expectedNamePreservingTypeSuffix]: obj[originalNameIncludingTypeSuffix]
+    }
+
+    const actual = normalizePropertyNames(obj, { camelCase: true })
+    expect(actual).toEqual(expected)
+  })
 })

--- a/packages/destination-actions/src/destinations/fullstory/vars.ts
+++ b/packages/destination-actions/src/destinations/fullstory/vars.ts
@@ -107,6 +107,19 @@ const typeSuffixPropertyName = (name: string, value: unknown) => {
   return name
 }
 
+const invalidPropertyNameCharRegex = /[^A-Za-z0-9_]/g
+
+const stripUnsupportedCharsFromPropertyName = (name: string) => {
+  const parts = name.split('_')
+  if (parts.length > 1) {
+    const typeSuffix = parts.pop()
+    if (typeSuffix) {
+      return parts.join('_').replace(invalidPropertyNameCharRegex, '') + `_${typeSuffix}`
+    }
+  }
+  return name.replace(invalidPropertyNameCharRegex, '')
+}
+
 /**
  * Normalizes first level property names according to FullStory API custom var expectations. Type suffixes
  * will be added to first level property names when a known type suffix isn't present and the type can be
@@ -127,6 +140,7 @@ export const normalizePropertyNames = (obj?: {}, options?: { camelCase?: boolean
     if (options?.camelCase) {
       transformedName = camelCasePropertyName(name)
     }
+    transformedName = stripUnsupportedCharsFromPropertyName(transformedName)
     return typeSuffixPropertyName(transformedName, value)
   }
 


### PR DESCRIPTION
Note: This PR is merging into another local branch to open for review into Segment's upstream `main` branch.

This PR strips unsupported chars from property names when sending custom user vars or custom event vars to FullStory. This allows Segment users tracking properties or traits with unsupported chars to send those properties and traits to FullStory without renaming the properties.

## Testing

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
