### PR TITLE
Add type suffixes to nested FullStory properties

### DIFF
--- a/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
@@ -99,6 +99,27 @@ describe('normalizePropertyNames', () => {
     expect(actual).toEqual(expected)
   })
 
+  it('type suffixes and camel cases nested properties', () => {
+    const originalPayload = {
+      parent: {
+        parent_string_prop: 'some string',
+        child: {
+          child_string_prop: 'some other string'
+        }
+      }
+    }
+    const expectedPayload = {
+      parent_obj: {
+        parentStringProp_str: originalPayload.parent.parent_string_prop,
+        child_obj: {
+          childStringProp_str: originalPayload.parent.child.child_string_prop
+        }
+      }
+    }
+    const transformedPayload = normalizePropertyNames(originalPayload, { camelCase: true })
+    expect(transformedPayload).toEqual(expectedPayload)
+  })
+
   const unsupportedPropertyNameChars = [' ', '.', '-', ':']
 
   unsupportedPropertyNameChars.forEach((char) => {

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
@@ -8,7 +8,7 @@ const suffixToExampleValuesMap: Record<string, any[]> = {
   real: [1, 1.23],
   int: [1],
   date: [new Date()],
-  obj: [{}, { secondLevelProp: 'some value' }]
+  obj: [{}, { second_level_string_prop: 'some value' }]
 }
 
 suffixToExampleValuesMap.strs = [suffixToExampleValuesMap.str]
@@ -43,7 +43,7 @@ describe('normalizePropertyNames', () => {
   })
 
   it('adds type suffixes when type can be inferred and known type suffix is absent', () => {
-    const obj = {
+    const originalPayload = {
       string_prop: suffixToExampleValuesMap.str[0],
       bool_prop1: suffixToExampleValuesMap.bool[0],
       bool_prop2: suffixToExampleValuesMap.bool[1],
@@ -60,27 +60,29 @@ describe('normalizePropertyNames', () => {
       dates_prop: suffixToExampleValuesMap.dates[0],
       objs_prop: suffixToExampleValuesMap.objs[0]
     }
-    const expected = {
-      string_prop_str: obj.string_prop,
-      bool_prop1_bool: obj.bool_prop1,
-      bool_prop2_bool: obj.bool_prop2,
-      real_prop1_real: obj.real_prop1,
-      real_prop2_real: obj.real_prop2,
+
+    const expectedPayload = {
+      string_prop_str: originalPayload.string_prop,
+      bool_prop1_bool: originalPayload.bool_prop1,
+      bool_prop2_bool: originalPayload.bool_prop2,
+      real_prop1_real: originalPayload.real_prop1,
+      real_prop2_real: originalPayload.real_prop2,
       // This may seem counter-intuitive, but this matches the FullStory client API behavior which prefers
       // reals over ints to avoid inconsistent type inference.
-      int_prop_real: obj.int_prop,
-      date_prop_date: obj.date_prop,
-      obj_prop1_obj: obj.obj_prop1,
-      obj_prop2_obj: obj.obj_prop2,
-      strs_prop_strs: obj.strs_prop,
-      bools_prop_bools: obj.bools_prop,
-      reals_prop_reals: obj.reals_prop,
-      ints_prop_reals: obj.ints_prop,
-      dates_prop_dates: obj.dates_prop,
-      objs_prop_objs: obj.objs_prop
+      int_prop_real: originalPayload.int_prop,
+      date_prop_date: originalPayload.date_prop,
+      obj_prop1_obj: originalPayload.obj_prop1,
+      obj_prop2_obj: originalPayload.obj_prop2,
+      strs_prop_strs: originalPayload.strs_prop,
+      bools_prop_bools: originalPayload.bools_prop,
+      reals_prop_reals: originalPayload.reals_prop,
+      ints_prop_reals: originalPayload.ints_prop,
+      dates_prop_dates: originalPayload.dates_prop,
+      objs_prop_objs: originalPayload.objs_prop
     }
-    const actual = normalizePropertyNames(obj)
-    expect(actual).toEqual(expected)
+
+    const transformedPayload = normalizePropertyNames(originalPayload)
+    expect(transformedPayload).toEqual(expectedPayload)
   })
 
   it('camel cases when specified', () => {

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
@@ -1,22 +1,21 @@
 import { normalizePropertyNames } from '../vars'
 
-const suffixToExampleValuesMap: Record<string, any[]> = {
-  str: ['some string'],
-  bool: [true, false],
+const suffixToExampleValuesMap: Record<string, any> = {
+  str: 'some string',
+  strs: ['string 1', 'string 2'],
+  bool: true,
+  bools: [true, false],
+  real: 1.23,
   // We include an int value with real example values since real will always be preferred when inferring
   // custom var types from values.
-  real: [1, 1.23],
-  int: [1],
-  date: [new Date()],
-  obj: [{}, { second_level_string_prop: 'some value' }]
+  reals: [1, 4.56],
+  int: 1,
+  ints: [2, 3],
+  date: new Date(2000, 1),
+  dates: [new Date(2000, 2), new Date(2000, 3)],
+  obj: {},
+  objs: [{}, { nested_string_str: 'nested string' }]
 }
-
-suffixToExampleValuesMap.strs = [suffixToExampleValuesMap.str]
-suffixToExampleValuesMap.bools = [suffixToExampleValuesMap.bool]
-suffixToExampleValuesMap.reals = [suffixToExampleValuesMap.real]
-suffixToExampleValuesMap.ints = [suffixToExampleValuesMap.int]
-suffixToExampleValuesMap.dates = [suffixToExampleValuesMap.date]
-suffixToExampleValuesMap.objs = [suffixToExampleValuesMap.obj]
 
 describe('normalizePropertyNames', () => {
   it('does not add type suffix for undefined values', () => {
@@ -33,10 +32,8 @@ describe('normalizePropertyNames', () => {
 
   it('does not add type suffix if known type suffix is present', () => {
     const obj: Record<string, unknown> = {}
-    Object.entries(suffixToExampleValuesMap).forEach(([suffix, values]) => {
-      values.forEach((value, index) => {
-        obj[`prop${index}_${suffix}`] = value
-      })
+    Object.entries(suffixToExampleValuesMap).forEach(([suffix, value]) => {
+      obj[`${suffix}_prop_${suffix}`] = value
     })
     const normalizedObj = normalizePropertyNames(obj)
     expect(normalizedObj).toEqual(obj)
@@ -44,40 +41,36 @@ describe('normalizePropertyNames', () => {
 
   it('adds type suffixes when type can be inferred and known type suffix is absent', () => {
     const originalPayload = {
-      string_prop: suffixToExampleValuesMap.str[0],
-      bool_prop1: suffixToExampleValuesMap.bool[0],
-      bool_prop2: suffixToExampleValuesMap.bool[1],
-      real_prop1: suffixToExampleValuesMap.real[0],
-      real_prop2: suffixToExampleValuesMap.real[1],
-      int_prop: suffixToExampleValuesMap.int[0],
-      date_prop: suffixToExampleValuesMap.date[0],
-      obj_prop1: suffixToExampleValuesMap.obj[0],
-      obj_prop2: suffixToExampleValuesMap.obj[1],
-      strs_prop: suffixToExampleValuesMap.strs[0],
-      bools_prop: suffixToExampleValuesMap.bools[0],
-      reals_prop: suffixToExampleValuesMap.reals[0],
-      ints_prop: suffixToExampleValuesMap.ints[0],
-      dates_prop: suffixToExampleValuesMap.dates[0],
-      objs_prop: suffixToExampleValuesMap.objs[0]
+      str_prop: suffixToExampleValuesMap.str,
+      strs_prop: suffixToExampleValuesMap.strs,
+      bool_prop1: suffixToExampleValuesMap.bool,
+      bool_prop2: !suffixToExampleValuesMap.bool,
+      bools_prop: suffixToExampleValuesMap.bools,
+      real_prop: suffixToExampleValuesMap.real,
+      reals_prop: suffixToExampleValuesMap.reals,
+      int_prop: suffixToExampleValuesMap.int,
+      ints_prop: suffixToExampleValuesMap.ints,
+      date_prop: suffixToExampleValuesMap.date,
+      dates_prop: suffixToExampleValuesMap.dates,
+      obj_prop: suffixToExampleValuesMap.obj,
+      objs_prop: suffixToExampleValuesMap.objs
     }
 
     const expectedPayload = {
-      string_prop_str: originalPayload.string_prop,
+      str_prop_str: originalPayload.str_prop,
+      strs_prop_strs: originalPayload.strs_prop,
       bool_prop1_bool: originalPayload.bool_prop1,
       bool_prop2_bool: originalPayload.bool_prop2,
-      real_prop1_real: originalPayload.real_prop1,
-      real_prop2_real: originalPayload.real_prop2,
+      bools_prop_bools: originalPayload.bools_prop,
+      real_prop_real: originalPayload.real_prop,
+      reals_prop_reals: originalPayload.reals_prop,
       // This may seem counter-intuitive, but this matches the FullStory client API behavior which prefers
       // reals over ints to avoid inconsistent type inference.
       int_prop_real: originalPayload.int_prop,
-      date_prop_date: originalPayload.date_prop,
-      obj_prop1_obj: originalPayload.obj_prop1,
-      obj_prop2_obj: originalPayload.obj_prop2,
-      strs_prop_strs: originalPayload.strs_prop,
-      bools_prop_bools: originalPayload.bools_prop,
-      reals_prop_reals: originalPayload.reals_prop,
       ints_prop_reals: originalPayload.ints_prop,
+      date_prop_date: originalPayload.date_prop,
       dates_prop_dates: originalPayload.dates_prop,
+      obj_prop_obj: originalPayload.obj_prop,
       objs_prop_objs: originalPayload.objs_prop
     }
 

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
@@ -99,20 +99,32 @@ describe('normalizePropertyNames', () => {
     expect(actual).toEqual(expected)
   })
 
-  it('type suffixes and camel cases nested properties', () => {
+  it('type suffixes and camel cases nested properties up to max depth', () => {
     const originalPayload = {
-      parent: {
-        parent_string_prop: 'some string',
-        child: {
-          child_string_prop: 'some other string'
+      first: {
+        second: {
+          third: {
+            fourth: {
+              fourth_nested: 'some string',
+              fifth: {
+                fifth_nested: 'some other string'
+              }
+            }
+          }
         }
       }
     }
     const expectedPayload = {
-      parent_obj: {
-        parentStringProp_str: originalPayload.parent.parent_string_prop,
-        child_obj: {
-          childStringProp_str: originalPayload.parent.child.child_string_prop
+      first_obj: {
+        second_obj: {
+          third_obj: {
+            fourth_obj: {
+              fourthNested_str: 'some string',
+              fifth_obj: {
+                fifth_nested: 'some other string'
+              }
+            }
+          }
         }
       }
     }

--- a/packages/destination-actions/src/destinations/fullstory/vars.ts
+++ b/packages/destination-actions/src/destinations/fullstory/vars.ts
@@ -168,7 +168,8 @@ export const normalizePropertyNames = (obj?: {}, options?: { camelCase?: boolean
   return Object.entries(obj).reduce(
     (acc, [key, value]) => ({
       ...acc,
-      [normalizePropertyName(key, value)]: value
+      [normalizePropertyName(key, value)]:
+        inferType(value) === 'obj' ? normalizePropertyNames(value as {}, options) : value
     }),
     {}
   )

--- a/packages/destination-actions/src/destinations/fullstory/vars.ts
+++ b/packages/destination-actions/src/destinations/fullstory/vars.ts
@@ -139,17 +139,50 @@ const transformPropertyName = (name: string, transformations: PropertyNameTransf
   return transform(name)
 }
 
+/** The maximum levels deep property names will be type suffixed and otherwise transformed e.g. camel cased **/
+const MAX_PROPERTY_NORMALIZATION_DEPTH = 5
+
 /**
- * Normalizes first level property names according to FullStory API custom var expectations. Type suffixes
- * will be added to first level property names when a known type suffix isn't present and the type can be
- * inferred. First level property names will also be camel cased if specified, preserving any known type
+ * Recursively transforms property names up to {@link MAX_PROPERTY_NORMALIZATION_DEPTH} levels deep.
+ *
+ * @param obj The source object with propery names to transform.
+ * @param transformPropertyName The function invoked to transform each property name.
+ * @param currentDepth The current recursion depth which is incremented each iteration (start at 1).
+ * @returns A new object with property names transformed using the given transformPropertyName function.
+ */
+const recursivelyTransformPropertyNames = (
+  obj: any,
+  transformPropertyName: (name: string, value: unknown) => string,
+  currentDepth: number
+): Record<string, unknown> => {
+  if (currentDepth > MAX_PROPERTY_NORMALIZATION_DEPTH) {
+    return obj
+  }
+
+  const normalizedObj: Record<string, unknown> = {}
+
+  Object.entries(obj).forEach(([key, value]) => {
+    const normalizedName = transformPropertyName(key, value)
+    normalizedObj[normalizedName] =
+      inferType(value) === 'obj'
+        ? recursivelyTransformPropertyNames(value, transformPropertyName, currentDepth + 1)
+        : value
+  })
+
+  return normalizedObj
+}
+
+/**
+ * Normalizes property names up to {@link MAX_PROPERTY_NORMALIZATION_DEPTH} levels deep according to FullStory API
+ * custom var expectations. Type suffixes will be added to property names when a known type suffix isn't present
+ * and the type can be inferred. Property names will also be camel cased if specified, preserving any known type
  * suffixes. Finally, any unsupported characters will be stripped from property names.
  *
- * @param obj The source object.
+ * @param obj The source object with property names to normalize.
  * @param options Extended normalization options, including whether to camel case property names.
- * @returns A new object with first level property names normalized.
+ * @returns A new object with property names normalized.
  */
-export const normalizePropertyNames = (obj?: {}, options?: { camelCase?: boolean }): Record<string, unknown> => {
+export const normalizePropertyNames = (obj?: any, options?: { camelCase?: boolean }): Record<string, unknown> => {
   if (!obj) {
     return {}
   }
@@ -165,12 +198,5 @@ export const normalizePropertyNames = (obj?: {}, options?: { camelCase?: boolean
     return typeSuffixPropertyName(transformedName, value)
   }
 
-  return Object.entries(obj).reduce(
-    (acc, [key, value]) => ({
-      ...acc,
-      [normalizePropertyName(key, value)]:
-        inferType(value) === 'obj' ? normalizePropertyNames(value as {}, options) : value
-    }),
-    {}
-  )
+  return recursivelyTransformPropertyNames(obj, normalizePropertyName, 1)
 }


### PR DESCRIPTION
Note: This PR is set to merge into another non-main local branch. After this internal FS review, we would request this destination non-main local branch be merged into Segment's upstream `main` branch.

Before this PR, FullStory custom event and custom user properties were type suffixed as required by FullStory's v1 events and users APIs. However, type suffixing was only applied to root level track properties and identify traits. In practice, mutual Segment and FullStory customers often pass in track properties or identify traits which are complex objects with nested properties. Since these nested properties were not type suffixed, these track and identify events would fail to be processed by FullStory's server APIs.

This PR adds type suffixing for properties up to 5 levels deep -- a depth which appears sufficient for the majority of FullStory customer custom event and custom user properties. 

## Testing

Unit tests were run, and full integration tests were carried out against FullStory production server APIs.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
