### PR TITLE
Don't add _obj type suffix to inferred FullStory object properties

### DIFF
--- a/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/var.test.ts
@@ -70,7 +70,8 @@ describe('normalizePropertyNames', () => {
       ints_prop_reals: originalPayload.ints_prop,
       date_prop_date: originalPayload.date_prop,
       dates_prop_dates: originalPayload.dates_prop,
-      obj_prop_obj: originalPayload.obj_prop,
+      // We don't add _obj type suffixes to object properties. This matches FullStory client API behavior.
+      obj_prop: originalPayload.obj_prop,
       objs_prop_objs: originalPayload.objs_prop
     }
 
@@ -115,12 +116,12 @@ describe('normalizePropertyNames', () => {
       }
     }
     const expectedPayload = {
-      first_obj: {
-        second_obj: {
-          third_obj: {
-            fourth_obj: {
+      first: {
+        second: {
+          third: {
+            fourth: {
               fourthNested_str: 'some string',
-              fifth_obj: {
+              fifth: {
                 fifth_nested: 'some other string'
               }
             }

--- a/packages/destination-actions/src/destinations/fullstory/vars.ts
+++ b/packages/destination-actions/src/destinations/fullstory/vars.ts
@@ -102,7 +102,7 @@ const typeSuffixPropertyName = (name: string, value: unknown) => {
     const maybeType = inferType(value)
     if (maybeType === null || maybeType === 'obj') {
       // If we can't infer the type or if the type is a single object, don't change the property name.
-      // The FullStory client API doesn't add _obj type suffixes to inferred objects.
+      // The FullStory client API doesn't add _obj type suffixes to inferred object propery names.
       return name
     }
 

--- a/packages/destination-actions/src/destinations/fullstory/vars.ts
+++ b/packages/destination-actions/src/destinations/fullstory/vars.ts
@@ -100,8 +100,9 @@ const typeSuffixPropertyName = (name: string, value: unknown) => {
   if (lastUnderscore === -1 || !isKnownTypeSuffix(name.substring(lastUnderscore + 1))) {
     // Either no type suffix or the name contains an underscore with an unknown suffix.
     const maybeType = inferType(value)
-    if (maybeType === null) {
-      // We can't infer the type. Don't change the property name.
+    if (maybeType === null || maybeType === 'obj') {
+      // If we can't infer the type or if the type is a single object, don't change the property name.
+      // The FullStory client API doesn't add _obj type suffixes to inferred objects.
       return name
     }
 


### PR DESCRIPTION
This PR stops adding `_obj` type suffixes to inferred object properties to match FullStory browser API behavior. This change isn't expected to impact existing FullStory Segment cloud mode destination consumers.

## Testing

Ran unit tests. Tested E2E using local server.

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
