### PR TITLE
Create track event v2 action

### DIFF
--- a/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
@@ -258,7 +258,7 @@ describe('FullStory', () => {
           second_property: 'second_value',
           thirdProperty: 'thirdValue',
           useRecentSession: true,
-          sessionUrl: `session/url/${sessionId}`
+          sessionUrl: `session/url/${encodeURIComponent(sessionId)}`
         },
         user: {
           uid: userId

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
@@ -209,4 +209,93 @@ describe('FullStory', () => {
       })
     })
   })
+
+  describe('trackEventV2', () => {
+    it('makes expected request with default mappings', async () => {
+      nock(baseUrl).post(`/v2beta/events?${integrationSourceQueryParam}`).reply(200)
+      const eventName = 'test-event'
+
+      const sessionId = '12345:678'
+
+      const properties = {
+        'first-property': 'first-value',
+        second_property: 'second_value',
+        thirdProperty: 'thirdValue',
+        useRecentSession: true,
+        sessionUrl: `session/url/${encodeURIComponent(sessionId)}`
+      }
+
+      const timestamp = new Date(Date.UTC(2022, 1, 2, 3, 4, 5)).toISOString()
+
+      const event = createTestEvent({
+        type: 'track',
+        userId,
+        event: eventName,
+        timestamp,
+        properties
+      })
+
+      const [response] = await testDestination.testAction('trackEventV2', {
+        settings,
+        event,
+        // Default mappings defined under fields in ../trackEvent/index.ts
+        useDefaultMappings: true,
+        mapping: {
+          useRecentSession: {
+            '@path': '$.properties.useRecentSession'
+          },
+          sessionUrl: {
+            '@path': '$.properties.sessionUrl'
+          }
+        }
+      })
+
+      expect(response.status).toBe(200)
+      expect(JSON.parse(response.options.body as string)).toEqual({
+        name: eventName,
+        properties: {
+          firstproperty: 'first-value',
+          second_property: 'second_value',
+          thirdProperty: 'thirdValue',
+          useRecentSession: true,
+          sessionUrl: `session/url/${sessionId}`
+        },
+        user: {
+          uid: userId
+        },
+        timestamp,
+        session: {
+          id: sessionId,
+          use_most_recent: properties.useRecentSession
+        }
+      })
+    })
+
+    it('handles undefined event values', async () => {
+      nock(baseUrl).post(`/v2beta/events?${integrationSourceQueryParam}`).reply(200)
+      const eventName = 'test-event'
+
+      const event = createTestEvent({
+        type: 'track',
+        userId,
+        event: eventName,
+        timestamp: undefined
+      })
+
+      const [response] = await testDestination.testAction('trackEventV2', {
+        settings,
+        event,
+        useDefaultMappings: true
+      })
+
+      expect(response.status).toBe(200)
+      expect(JSON.parse(response.options.body as string)).toEqual({
+        name: eventName,
+        properties: {},
+        user: {
+          uid: userId
+        }
+      })
+    })
+  })
 })

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
@@ -238,7 +238,7 @@ describe('FullStory', () => {
       const [response] = await testDestination.testAction('trackEventV2', {
         settings,
         event,
-        // Default mappings defined under fields in ../trackEvent/index.ts
+        // Default mappings defined under fields in ../trackEventV2/index.ts
         useDefaultMappings: true,
         mapping: {
           useRecentSession: {

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
@@ -172,6 +172,7 @@ describe('requestParams', () => {
       expect(options.method).toBe('post')
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
+      expect(options.headers!['Integration-Source']).toBe(integrationSource)
       expect(url).toBe(`${baseUrl}/v2beta/events?${integrationSourceQueryParam}`)
       expect(options.json).toEqual({
         name: requestValues.eventName,
@@ -197,6 +198,7 @@ describe('requestParams', () => {
       expect(options.method).toBe('post')
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
+      expect(options.headers!['Integration-Source']).toBe(integrationSource)
       expect(url).toBe(`${baseUrl}/v2beta/events?${integrationSourceQueryParam}`)
       expect(options.json).toEqual({
         name: requestValues.eventName,
@@ -218,6 +220,7 @@ describe('requestParams', () => {
       expect(options.method).toBe('post')
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
+      expect(options.headers!['Integration-Source']).toBe(integrationSource)
       expect(url).toBe(`${baseUrl}/v2beta/events?${integrationSourceQueryParam}`)
       expect(options.json).toEqual({
         name: requestValues.eventName,

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
@@ -3,7 +3,8 @@ import {
   customEventRequestParams,
   setUserPropertiesRequestParams,
   deleteUserRequestParams,
-  createUserRequestParams
+  createUserRequestParams,
+  createEventRequestParams
 } from '../request-params'
 import {
   anonymousId,
@@ -149,6 +150,82 @@ describe('requestParams', () => {
       expect(options.headers!['Integration-Source']).toBe(integrationSource)
       expect(url).toBe(`${baseUrl}/v2beta/users?${integrationSourceQueryParam}`)
       expect(options.json).toEqual(requestBody)
+    })
+  })
+
+  describe('customEventV2', () => {
+    it('returns expected request params', () => {
+      const sessionId = 'ec5218650ee0:a58ec087'
+      const requestValues = {
+        userId,
+        eventName: 'test-event',
+        properties: {
+          'first-property': 'first-value',
+          second_property: 'second_value',
+          thirdProperty: 'thirdValue'
+        },
+        timestamp: new Date(Date.UTC(2022, 1, 2, 3, 4, 5)).toISOString(),
+        useRecentSession: true,
+        sessionUrl: `session/url/${encodeURIComponent(sessionId)}`
+      }
+      const { url, options } = createEventRequestParams(settings, requestValues)
+      expect(options.method).toBe('post')
+      expect(options.headers!['Content-Type']).toBe('application/json')
+      expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
+      expect(url).toBe(`${baseUrl}/v2beta/events?${integrationSourceQueryParam}`)
+      expect(options.json).toEqual({
+        name: requestValues.eventName,
+        properties: requestValues.properties,
+        user: {
+          uid: userId
+        },
+        timestamp: requestValues.timestamp,
+        session: {
+          id: sessionId,
+          use_most_recent: requestValues.useRecentSession
+        }
+      })
+    })
+
+    it('handles undefined request values', () => {
+      const requestValues = {
+        userId,
+        eventName: 'test-event',
+        properties: {}
+      }
+      const { url, options } = createEventRequestParams(settings, requestValues)
+      expect(options.method).toBe('post')
+      expect(options.headers!['Content-Type']).toBe('application/json')
+      expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
+      expect(url).toBe(`${baseUrl}/v2beta/events?${integrationSourceQueryParam}`)
+      expect(options.json).toEqual({
+        name: requestValues.eventName,
+        properties: requestValues.properties,
+        user: {
+          uid: userId
+        }
+      })
+    })
+
+    it('omits use_most_recent request param if false', () => {
+      const requestValues = {
+        userId,
+        eventName: 'test-event',
+        properties: {},
+        useRecentSession: false
+      }
+      const { url, options } = createEventRequestParams(settings, requestValues)
+      expect(options.method).toBe('post')
+      expect(options.headers!['Content-Type']).toBe('application/json')
+      expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
+      expect(url).toBe(`${baseUrl}/v2beta/events?${integrationSourceQueryParam}`)
+      expect(options.json).toEqual({
+        name: requestValues.eventName,
+        properties: requestValues.properties,
+        user: {
+          uid: userId
+        }
+      })
     })
   })
 })

--- a/packages/destination-actions/src/destinations/fullstory/generated-types.ts
+++ b/packages/destination-actions/src/destinations/fullstory/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Settings {
   /**
-   * [FullStory API key](https://help.fullstory.com/hc/en-us/articles/360052021773-Managing-API-Keys)
+   * [FullStory Admin API key](https://help.fullstory.com/hc/en-us/articles/360052021773-Managing-API-Keys)
    */
   apiKey: string
 }

--- a/packages/destination-actions/src/destinations/fullstory/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/index.ts
@@ -4,6 +4,7 @@ import type { Settings } from './generated-types'
 import identifyUser from './identifyUser'
 import trackEvent from './trackEvent'
 import identifyUserV2 from './identifyUserV2'
+import trackEventV2 from './trackEventV2'
 import { listOperationsRequestParams, deleteUserRequestParams } from './request-params'
 
 const destination: DestinationDefinition<Settings> = {
@@ -52,6 +53,7 @@ const destination: DestinationDefinition<Settings> = {
   actions: {
     trackEvent,
     identifyUser,
+    trackEventV2,
     identifyUserV2
   }
 }

--- a/packages/destination-actions/src/destinations/fullstory/trackEventV2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/fullstory/trackEventV2/generated-types.ts
@@ -1,0 +1,30 @@
+// Generated file. DO NOT MODIFY IT BY HAND.
+
+export interface Payload {
+  /**
+   * The user's id
+   */
+  userId: string
+  /**
+   * The name of the event.
+   */
+  name: string
+  /**
+   * A JSON object containing additional information about the event that will be indexed by FullStory.
+   */
+  properties?: {
+    [k: string]: unknown
+  }
+  /**
+   * The date and time when the event occurred. If not provided, the current FullStory server time will be used.
+   */
+  timestamp?: string | number
+  /**
+   * Set to true if the custom event should be attached to the user's most recent session. The most recent session must have had activity within the past 30 minutes.
+   */
+  useRecentSession?: boolean
+  /**
+   * If known, the FullStory session playback URL to which the event should be attached, as returned by the FS.getCurrentSessionURL() client API.
+   */
+  sessionUrl?: string
+}

--- a/packages/destination-actions/src/destinations/fullstory/trackEventV2/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/trackEventV2/index.ts
@@ -1,0 +1,82 @@
+import type { ActionDefinition } from '@segment/actions-core'
+import dayjs from '../../../lib/dayjs'
+import type { Settings } from '../generated-types'
+import type { Payload } from './generated-types'
+import { createEventRequestParams } from '../request-params'
+import { normalizePropertyNames } from '../vars'
+
+const action: ActionDefinition<Settings, Payload> = {
+  title: 'Track Event',
+  description: 'Track events V2',
+  platform: 'cloud',
+  defaultSubscription: 'type = "track"',
+  fields: {
+    userId: {
+      type: 'string',
+      required: true,
+      description: "The user's id",
+      label: 'User ID',
+      default: {
+        '@path': '$.userId'
+      }
+    },
+    name: {
+      description: 'The name of the event.',
+      label: 'Name',
+      required: true,
+      type: 'string',
+      default: {
+        '@path': '$.event'
+      }
+    },
+    properties: {
+      description: 'A JSON object containing additional information about the event that will be indexed by FullStory.',
+      label: 'Properties',
+      required: false,
+      type: 'object',
+      default: {
+        '@path': '$.properties'
+      }
+    },
+    timestamp: {
+      description:
+        'The date and time when the event occurred. If not provided, the current FullStory server time will be used.',
+      label: 'Timestamp',
+      required: false,
+      type: 'datetime',
+      default: {
+        '@path': '$.timestamp'
+      }
+    },
+    useRecentSession: {
+      description:
+        "Set to true if the custom event should be attached to the user's most recent session. The most recent session must have had activity within the past 30 minutes.",
+      label: 'Use Recent Session',
+      required: false,
+      type: 'boolean'
+    },
+    sessionUrl: {
+      description:
+        'If known, the FullStory session playback URL to which the event should be attached, as returned by the FS.getCurrentSessionURL() client API.',
+      label: 'Session URL',
+      required: false,
+      type: 'string'
+    }
+  },
+  perform: (request, { payload, settings }) => {
+    const { userId, name, properties, timestamp, useRecentSession, sessionUrl } = payload
+    const utcTimestamp = timestamp ? dayjs.utc(timestamp) : undefined
+
+    const { url, options } = createEventRequestParams(settings, {
+      userId,
+      eventName: name,
+      properties: normalizePropertyNames(properties),
+      timestamp: utcTimestamp && utcTimestamp.isValid() ? utcTimestamp.toISOString() : undefined,
+      useRecentSession,
+      sessionUrl
+    })
+    return request(url, options)
+  }
+}
+
+export default action

--- a/packages/destination-actions/src/destinations/fullstory/trackEventV2/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/trackEventV2/index.ts
@@ -6,8 +6,8 @@ import { createEventRequestParams } from '../request-params'
 import { normalizePropertyNames } from '../vars'
 
 const action: ActionDefinition<Settings, Payload> = {
-  title: 'Track Event',
-  description: 'Track events V2',
+  title: 'Track Event V2',
+  description: 'Track events V2.',
   platform: 'cloud',
   defaultSubscription: 'type = "track"',
   fields: {


### PR DESCRIPTION
Note: This is into another local branch that will eventually be a PR into the main branch.

This PR adds a new action to the existing FullStory Cloud Mode destination. The new action recreates Track Event using the [V2 endpoint](https://developer.fullstory.com/server/v2/events/create-events/).

This PR depends on [another PR](https://github.com/cowpaths/segmentio-action-destinations/pull/14).

## Testing

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment

[ECO-8408]

[ECO-8408]: https://fullstory.atlassian.net/browse/ECO-8408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ