### PR TITLE
Update API Key Requirements

### DIFF
--- a/packages/destination-actions/src/destinations/fullstory/generated-types.ts
+++ b/packages/destination-actions/src/destinations/fullstory/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Settings {
   /**
-   * [FullStory Admin API key](https://help.fullstory.com/hc/en-us/articles/360052021773-Managing-API-Keys)
+   * [FullStory API key](https://help.fullstory.com/hc/en-us/articles/360052021773-Managing-API-Keys). An `Admin` or `Architect` API Key is necessary for GDPR deletions to propagate, otherwise a `Standard` API Key will work.
    */
   apiKey: string
 }

--- a/packages/destination-actions/src/destinations/fullstory/generated-types.ts
+++ b/packages/destination-actions/src/destinations/fullstory/generated-types.ts
@@ -2,7 +2,7 @@
 
 export interface Settings {
   /**
-   * [FullStory API key](https://help.fullstory.com/hc/en-us/articles/360052021773-Managing-API-Keys). An `Admin` or `Architect` API Key is necessary for GDPR deletions to propagate, otherwise a `Standard` API Key will work.
+   * [FullStory API key](https://help.fullstory.com/hc/en-us/articles/360052021773-Managing-API-Keys). An `Admin` or `Architect` API Key is necessary for GDPR deletions to propagate. Otherwise, a `Standard` API Key is sufficient for FullStory actions.
    */
   apiKey: string
 }

--- a/packages/destination-actions/src/destinations/fullstory/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/index.ts
@@ -8,7 +8,7 @@ import trackEventV2 from './trackEventV2'
 import { listOperationsRequestParams, deleteUserRequestParams } from './request-params'
 
 const destination: DestinationDefinition<Settings> = {
-  name: 'Fullstory Cloud Mode (Actions)',
+  name: 'FullStory Cloud Mode (Actions)',
   slug: 'actions-fullstory-cloud',
   mode: 'cloud',
   presets: [
@@ -30,7 +30,9 @@ const destination: DestinationDefinition<Settings> = {
     fields: {
       apiKey: {
         label: 'API Key',
-        description: '[FullStory API key](https://help.fullstory.com/hc/en-us/articles/360052021773-Managing-API-Keys)',
+        description:
+          '[FullStory API key](https://help.fullstory.com/hc/en-us/articles/360052021773-Managing-API-Keys). An `Admin` or `Architect` API Key ' +
+          'is necessary for GDPR deletions to propagate, otherwise a `Standard` API Key will work.',
         type: 'password',
         required: true
       }

--- a/packages/destination-actions/src/destinations/fullstory/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/index.ts
@@ -32,7 +32,7 @@ const destination: DestinationDefinition<Settings> = {
         label: 'API Key',
         description:
           '[FullStory API key](https://help.fullstory.com/hc/en-us/articles/360052021773-Managing-API-Keys). An `Admin` or `Architect` API Key ' +
-          'is necessary for GDPR deletions to propagate, otherwise a `Standard` API Key will work.',
+          'is necessary for GDPR deletions to propagate. Otherwise, a `Standard` API Key is sufficient for FullStory actions.',
         type: 'password',
         required: true
       }


### PR DESCRIPTION
Updating wording to indicate when an `Admin` or `Architect` API Key is required as opposed to a `Standard` API Key.

## Testing

- [ ] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
