### PR TITLE
Segment Actions Improvements

### DIFF
--- a/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
@@ -156,7 +156,7 @@ describe('FullStory', () => {
   describe('onDelete', () => {
     const falsyUserIds = ['', undefined, null]
     it('makes expected request given a valid user id', async () => {
-      nock(baseUrl).delete(`/v2beta/users?uid=${urlEncodedUserId}`).reply(200)
+      nock(baseUrl).delete(`/v2/users?uid=${urlEncodedUserId}`).reply(200)
       await expect(testDestination.onDelete!({ type: 'delete', userId }, settings)).resolves.not.toThrowError()
     })
 
@@ -171,7 +171,7 @@ describe('FullStory', () => {
 
   describe('identifyUserV2', () => {
     it('makes expected request with default mappings', async () => {
-      nock(baseUrl).post(`/v2beta/users?${integrationSourceQueryParam}`).reply(200)
+      nock(baseUrl).post(`/v2/users?${integrationSourceQueryParam}`).reply(200)
       const event = createTestEvent({
         type: 'identify',
         userId,
@@ -212,7 +212,7 @@ describe('FullStory', () => {
 
   describe('trackEventV2', () => {
     it('makes expected request with default mappings', async () => {
-      nock(baseUrl).post(`/v2beta/events?${integrationSourceQueryParam}`).reply(200)
+      nock(baseUrl).post(`/v2/events?${integrationSourceQueryParam}`).reply(200)
       const eventName = 'test-event'
 
       const sessionId = '12345:678'
@@ -272,7 +272,7 @@ describe('FullStory', () => {
     })
 
     it('handles undefined event values', async () => {
-      nock(baseUrl).post(`/v2beta/events?${integrationSourceQueryParam}`).reply(200)
+      nock(baseUrl).post(`/v2/events?${integrationSourceQueryParam}`).reply(200)
       const eventName = 'test-event'
 
       const event = createTestEvent({

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
@@ -171,7 +171,7 @@ describe('FullStory', () => {
 
   describe('identifyUserV2', () => {
     it('makes expected request with default mappings', async () => {
-      nock(baseUrl).post(`/v2/users?${integrationSourceQueryParam}`).reply(200)
+      nock(baseUrl).post(`/v2/users`).reply(200)
       const event = createTestEvent({
         type: 'identify',
         userId,
@@ -212,7 +212,7 @@ describe('FullStory', () => {
 
   describe('trackEventV2', () => {
     it('makes expected request with default mappings', async () => {
-      nock(baseUrl).post(`/v2/events?${integrationSourceQueryParam}`).reply(200)
+      nock(baseUrl).post(`/v2/events`).reply(200)
       const eventName = 'test-event'
 
       const sessionId = '12345:678'
@@ -272,7 +272,7 @@ describe('FullStory', () => {
     })
 
     it('handles undefined event values', async () => {
-      nock(baseUrl).post(`/v2/events?${integrationSourceQueryParam}`).reply(200)
+      nock(baseUrl).post(`/v2/events`).reply(200)
       const eventName = 'test-event'
 
       const event = createTestEvent({

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/fullstory.test.ts
@@ -18,7 +18,7 @@ const testDestination = createTestIntegration(Definition)
 describe('FullStory', () => {
   describe('testAuthentication', () => {
     it('makes expected request', async () => {
-      nock(baseUrl).get('/operations/v1?limit=1').reply(200)
+      nock(baseUrl).get('/me').reply(200)
       await expect(testDestination.testAuthentication(settings)).resolves.not.toThrowError()
     })
   })

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
@@ -129,7 +129,7 @@ describe('requestParams', () => {
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
       expect(options.headers!['Integration-Source']).toBe(integrationSource)
-      expect(url).toBe(`${baseUrl}/v2beta/users?uid=${urlEncodedUserId}`)
+      expect(url).toBe(`${baseUrl}/v2/users?uid=${urlEncodedUserId}`)
     })
   })
 
@@ -148,7 +148,7 @@ describe('requestParams', () => {
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
       expect(options.headers!['Integration-Source']).toBe(integrationSource)
-      expect(url).toBe(`${baseUrl}/v2beta/users?${integrationSourceQueryParam}`)
+      expect(url).toBe(`${baseUrl}/v2/users?${integrationSourceQueryParam}`)
       expect(options.json).toEqual(requestBody)
     })
   })
@@ -173,7 +173,7 @@ describe('requestParams', () => {
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
       expect(options.headers!['Integration-Source']).toBe(integrationSource)
-      expect(url).toBe(`${baseUrl}/v2beta/events?${integrationSourceQueryParam}`)
+      expect(url).toBe(`${baseUrl}/v2/events?${integrationSourceQueryParam}`)
       expect(options.json).toEqual({
         name: requestValues.eventName,
         properties: requestValues.properties,
@@ -199,7 +199,7 @@ describe('requestParams', () => {
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
       expect(options.headers!['Integration-Source']).toBe(integrationSource)
-      expect(url).toBe(`${baseUrl}/v2beta/events?${integrationSourceQueryParam}`)
+      expect(url).toBe(`${baseUrl}/v2/events?${integrationSourceQueryParam}`)
       expect(options.json).toEqual({
         name: requestValues.eventName,
         properties: requestValues.properties,
@@ -221,7 +221,7 @@ describe('requestParams', () => {
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
       expect(options.headers!['Integration-Source']).toBe(integrationSource)
-      expect(url).toBe(`${baseUrl}/v2beta/events?${integrationSourceQueryParam}`)
+      expect(url).toBe(`${baseUrl}/v2/events?${integrationSourceQueryParam}`)
       expect(options.json).toEqual({
         name: requestValues.eventName,
         properties: requestValues.properties,

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
@@ -1,10 +1,10 @@
 import {
-  listOperationsRequestParams,
   customEventRequestParams,
   setUserPropertiesRequestParams,
   deleteUserRequestParams,
   createUserRequestParams,
-  createEventRequestParams
+  createEventRequestParams,
+  meRequestParams
 } from '../request-params'
 import {
   anonymousId,
@@ -19,14 +19,14 @@ import {
 } from './fullstory.test'
 
 describe('requestParams', () => {
-  describe('listOperations', () => {
-    it(`returns expected request params`, () => {
-      const { url, options } = listOperationsRequestParams(settings)
+  describe('me', () => {
+    it('returns expected request params', () => {
+      const { url, options } = meRequestParams(settings)
       expect(options.method).toBe('get')
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
       expect(options.headers!['Integration-Source']).toBe(integrationSource)
-      expect(url).toBe(`${baseUrl}/operations/v1?limit=1`)
+      expect(url).toBe(`${baseUrl}/me`)
     })
   })
 

--- a/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
+++ b/packages/destination-actions/src/destinations/fullstory/__tests__/request-params.test.ts
@@ -148,7 +148,7 @@ describe('requestParams', () => {
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
       expect(options.headers!['Integration-Source']).toBe(integrationSource)
-      expect(url).toBe(`${baseUrl}/v2/users?${integrationSourceQueryParam}`)
+      expect(url).toBe(`${baseUrl}/v2/users`)
       expect(options.json).toEqual(requestBody)
     })
   })
@@ -173,7 +173,7 @@ describe('requestParams', () => {
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
       expect(options.headers!['Integration-Source']).toBe(integrationSource)
-      expect(url).toBe(`${baseUrl}/v2/events?${integrationSourceQueryParam}`)
+      expect(url).toBe(`${baseUrl}/v2/events`)
       expect(options.json).toEqual({
         name: requestValues.eventName,
         properties: requestValues.properties,
@@ -199,7 +199,7 @@ describe('requestParams', () => {
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
       expect(options.headers!['Integration-Source']).toBe(integrationSource)
-      expect(url).toBe(`${baseUrl}/v2/events?${integrationSourceQueryParam}`)
+      expect(url).toBe(`${baseUrl}/v2/events`)
       expect(options.json).toEqual({
         name: requestValues.eventName,
         properties: requestValues.properties,
@@ -221,7 +221,7 @@ describe('requestParams', () => {
       expect(options.headers!['Content-Type']).toBe('application/json')
       expect(options.headers!['Authorization']).toBe(`Basic ${settings.apiKey}`)
       expect(options.headers!['Integration-Source']).toBe(integrationSource)
-      expect(url).toBe(`${baseUrl}/v2/events?${integrationSourceQueryParam}`)
+      expect(url).toBe(`${baseUrl}/v2/events`)
       expect(options.json).toEqual({
         name: requestValues.eventName,
         properties: requestValues.properties,

--- a/packages/destination-actions/src/destinations/fullstory/identifyUserV2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/fullstory/identifyUserV2/generated-types.ts
@@ -4,7 +4,7 @@ export interface Payload {
   /**
    * The user's id
    */
-  uid: string
+  uid?: string
   /**
    * The user's anonymous id
    */

--- a/packages/destination-actions/src/destinations/fullstory/identifyUserV2/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/identifyUserV2/index.ts
@@ -11,7 +11,7 @@ const action: ActionDefinition<Settings> = {
   fields: {
     uid: {
       type: 'string',
-      required: true,
+      required: false,
       description: "The user's id",
       label: 'User ID',
       default: {

--- a/packages/destination-actions/src/destinations/fullstory/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/index.ts
@@ -5,7 +5,7 @@ import identifyUser from './identifyUser'
 import trackEvent from './trackEvent'
 import identifyUserV2 from './identifyUserV2'
 import trackEventV2 from './trackEventV2'
-import { listOperationsRequestParams, deleteUserRequestParams } from './request-params'
+import { deleteUserRequestParams, meRequestParams } from './request-params'
 
 const destination: DestinationDefinition<Settings> = {
   name: 'Fullstory Cloud Mode (Actions)',
@@ -39,7 +39,7 @@ const destination: DestinationDefinition<Settings> = {
     },
 
     testAuthentication: (request, { settings }) => {
-      const { url, options } = listOperationsRequestParams(settings)
+      const { url, options } = meRequestParams(settings)
       return request(url, options)
     }
   },

--- a/packages/destination-actions/src/destinations/fullstory/request-params.ts
+++ b/packages/destination-actions/src/destinations/fullstory/request-params.ts
@@ -169,7 +169,7 @@ export const createUserRequestParams = (settings: Settings, requestBody: Object)
 export const createEventRequestParams = (
   settings: Settings,
   requestValues: {
-    userId: string
+    userId?: string
     eventName: string
     properties: {}
     timestamp?: string

--- a/packages/destination-actions/src/destinations/fullstory/request-params.ts
+++ b/packages/destination-actions/src/destinations/fullstory/request-params.ts
@@ -130,7 +130,7 @@ export const setUserPropertiesRequestParams = (
  * @param userId The id of the user to delete.
  */
 export const deleteUserRequestParams = (settings: Settings, userId: string): RequestParams => {
-  const defaultParams = defaultRequestParams(settings, `v2beta/users?uid=${encodeURIComponent(userId)}`)
+  const defaultParams = defaultRequestParams(settings, `v2/users?uid=${encodeURIComponent(userId)}`)
 
   return {
     ...defaultParams,
@@ -148,7 +148,7 @@ export const deleteUserRequestParams = (settings: Settings, userId: string): Req
  * @param requestBody The request body containing user properties to set.
  */
 export const createUserRequestParams = (settings: Settings, requestBody: Object): RequestParams => {
-  const defaultParams = defaultRequestParams(settings, `v2beta/users?${integrationSourceQueryParam}`)
+  const defaultParams = defaultRequestParams(settings, `v2/users?${integrationSourceQueryParam}`)
 
   return {
     ...defaultParams,
@@ -178,7 +178,7 @@ export const createEventRequestParams = (
   }
 ): RequestParams => {
   const { userId, eventName, properties: eventData, timestamp, useRecentSession, sessionUrl } = requestValues
-  const defaultParams = defaultRequestParams(settings, `v2beta/events?${integrationSourceQueryParam}`)
+  const defaultParams = defaultRequestParams(settings, `v2/events?${integrationSourceQueryParam}`)
 
   const requestBody: Record<string, any> = {
     name: eventName,

--- a/packages/destination-actions/src/destinations/fullstory/request-params.ts
+++ b/packages/destination-actions/src/destinations/fullstory/request-params.ts
@@ -34,12 +34,11 @@ const defaultRequestParams = (settings: Settings, relativeUrl: string): RequestP
 }
 
 /**
- * Returns {@link RequestParams} for the list operations HTTP API endpoint.
+ * Returns {@link RequestParams} for the me HTTP API endpoint.
  *
  * @param settings Settings configured for the cloud mode destination.
  */
-export const listOperationsRequestParams = (settings: Settings): RequestParams =>
-  defaultRequestParams(settings, `operations/v1?limit=1`)
+export const meRequestParams = (settings: Settings): RequestParams => defaultRequestParams(settings, 'me')
 
 /**
  * Returns {@link RequestParams} for the V1 custom events HTTP API endpoint.

--- a/packages/destination-actions/src/destinations/fullstory/request-params.ts
+++ b/packages/destination-actions/src/destinations/fullstory/request-params.ts
@@ -148,7 +148,7 @@ export const deleteUserRequestParams = (settings: Settings, userId: string): Req
  * @param requestBody The request body containing user properties to set.
  */
 export const createUserRequestParams = (settings: Settings, requestBody: Object): RequestParams => {
-  const defaultParams = defaultRequestParams(settings, `v2/users?${integrationSourceQueryParam}`)
+  const defaultParams = defaultRequestParams(settings, `v2/users`)
 
   return {
     ...defaultParams,
@@ -178,7 +178,7 @@ export const createEventRequestParams = (
   }
 ): RequestParams => {
   const { userId, eventName, properties: eventData, timestamp, useRecentSession, sessionUrl } = requestValues
-  const defaultParams = defaultRequestParams(settings, `v2/events?${integrationSourceQueryParam}`)
+  const defaultParams = defaultRequestParams(settings, `v2/events`)
 
   const requestBody: Record<string, any> = {
     name: eventName,

--- a/packages/destination-actions/src/destinations/fullstory/trackEventV2/generated-types.ts
+++ b/packages/destination-actions/src/destinations/fullstory/trackEventV2/generated-types.ts
@@ -4,7 +4,7 @@ export interface Payload {
   /**
    * The user's id
    */
-  userId: string
+  userId?: string
   /**
    * The name of the event.
    */

--- a/packages/destination-actions/src/destinations/fullstory/trackEventV2/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/trackEventV2/index.ts
@@ -13,7 +13,7 @@ const action: ActionDefinition<Settings, Payload> = {
   fields: {
     userId: {
       type: 'string',
-      required: true,
+      required: false,
       description: "The user's id",
       label: 'User ID',
       default: {


### PR DESCRIPTION
## This PR has a few small changes

- Change routes from /v2beta to /v2 now that the V2 API is out of beta
- Change `testAuthentication` to use the /me endpoint as it is a cleaner endpoint
- Remove the required tag from TraveEventV2 `userId` and IdentifyUserV2 `uid` as these are not required properties.

## Testing

- [X] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [X] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [ ] [Segmenters] Tested in the staging environment
